### PR TITLE
ci: build and release on push to master

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -1,0 +1,108 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  packages: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.semantic_release.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "*"
+
+      - name: Install dependencies
+        run: npm install -g semantic-release @semantic-release/changelog conventional-changelog-conventionalcommits @semantic-release/git
+
+      - name: Get next version
+        id: semantic_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(semantic-release --dry-run | grep "next release version is" | sed -E 's/.* ([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?).*/\1/')
+          echo -e "\033[1;32mDry run version: $version\033[0m"
+          if [ ! -z "$version" ]; then
+            echo "version=$version" >> $GITHUB_OUTPUT
+          fi
+
+  build:
+    needs: version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: app
+            context: .
+            file: ./app/Dockerfile
+          - name: backend
+            context: backend
+            file: ./backend/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          push: ${{ github.event_name == 'push' && needs.version.outputs.version != '' }}
+          tags: |
+            ghcr.io/${{ github.repository }}-${{ matrix.name }}:${{ needs.version.outputs.version || '0.0.0' }}
+            ghcr.io/${{ github.repository }}-${{ matrix.name }}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+  release:
+    needs: [version, build]
+    if: needs.version.outputs.version != '' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "*"
+
+      - name: Install dependencies
+        run: npm install -g semantic-release @semantic-release/changelog conventional-changelog-conventionalcommits @semantic-release/git
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: semantic-release

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,112 @@
+{
+  "branches": ["master"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          {
+            "type": "refactor",
+            "release": "patch"
+          },
+          {
+            "type": "docs",
+            "scope": "README",
+            "release": "patch"
+          },
+          {
+            "type": "test",
+            "release": "patch"
+          },
+          {
+            "type": "style",
+            "release": "patch"
+          },
+          {
+            "type": "perf",
+            "release": "patch"
+          },
+          {
+            "type": "ci",
+            "release": "patch"
+          },
+          {
+            "type": "build",
+            "release": "patch"
+          },
+          {
+            "type": "chore",
+            "release": "patch"
+          },
+          {
+            "type": "chore",
+            "scope": "deps",
+            "release": false
+          },
+          {
+            "type": "no-release",
+            "release": false
+          }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            {
+              "type": "feat",
+              "section": ":sparkles: Features",
+              "hidden": false
+            },
+            {
+              "type": "fix",
+              "section": ":bug: Fixes",
+              "hidden": false
+            },
+            {
+              "type": "docs",
+              "section": ":memo: Documentation",
+              "hidden": false
+            },
+            {
+              "type": "style",
+              "section": ":barber: Code-style",
+              "hidden": false
+            },
+            {
+              "type": "refactor",
+              "section": ":zap: Refactor",
+              "hidden": false
+            },
+            {
+              "type": "perf",
+              "section": ":fast_forward: Performance",
+              "hidden": false
+            },
+            {
+              "type": "test",
+              "section": ":white_check_mark: Tests",
+              "hidden": false
+            },
+            {
+              "type": "ci",
+              "section": ":repeat: CI",
+              "hidden": false
+            },
+            {
+              "type": "chore",
+              "section": ":repeat: Chore",
+              "hidden": false
+            }
+          ]
+        }
+      }
+    ],
+    "@semantic-release/github",
+    "@semantic-release/git"
+  ]
+}
+

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,13 +1,30 @@
 FROM node:20 AS build
 
+
+ARG VITE_API_URL
+ARG VITE_PUSH_SERVER_KEY
+
+ENV VITE_API_URL=$VITE_API_URL
+ENV VITE_PUSH_SERVER_KEY=$VITE_PUSH_SERVER_KEY
+
 WORKDIR /monorepo
 COPY . .
 RUN npm install
 
 WORKDIR /monorepo/app
+
+RUN echo "VITE_APP_URL=$VITE_API_URL" && echo "VITE_PUSH_SERVER_KEY=$VITE_PUSH_SERVER_KEY"
+
 RUN npm run build
 
 FROM nginx:stable-alpine AS production-stage
+
+# Copy build output
 COPY --from=build /monorepo/app/dist /usr/share/nginx/html
+
+# Add custom nginx config
+COPY ./app/nginx.conf /etc/nginx/conf.d/default.conf
+
 EXPOSE 80
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -7,7 +7,7 @@ RUN npm install
 WORKDIR /monorepo/app
 RUN npm run build
 
-FROM nginx:stable-alpine as production-stage
+FROM nginx:stable-alpine AS production-stage
 COPY --from=build /monorepo/app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -1,0 +1,20 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # Cache static assets for 3 days
+  location ~* \.(?:js|css|woff2?|eot|ttf|otf|png|jpe?g|gif|svg|ico)$ {
+    expires 3d;
+    access_log off;
+    add_header Cache-Control "public, max-age=259200"; # 3 days = 259200 seconds
+    try_files $uri =404;
+  }
+
+  # Serve index.html for SPA routes
+  location / {
+    try_files $uri /index.html;
+  }
+}

--- a/docker-compose-coolify.yml
+++ b/docker-compose-coolify.yml
@@ -1,0 +1,46 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: ./app/Dockerfile
+      args:
+        VITE_API_URL:
+        VITE_PUSH_SERVER_KEY:
+    volumes:
+      - ./app:/app
+      - /app/node_modules
+    environment:
+      - VITE_API_URL=${VITE_API_URL}
+      - VITE_PUSH_SERVER_KEY=${VITE_PUSH_SERVER_KEY}
+
+  backend:
+    build:
+      context: ./backend
+      args:
+        DATABASE_URL: mysql://root:12345678@mysql:3306/operational
+    environment:
+      - DATABASE_URL=mysql://root:12345678@mysql:3306/operational
+      - APP_URL=${APP_URL}
+      - API_URL=${API_URL}
+      - CORS=*
+      - NODE_ENV=production
+      - VAPID_EMAIL=${VAPID_EMAIL}
+      - VAPID_PUBLIC_KEY=${VAPID_PUBLIC_KEY}
+      - VAPID_PRIVATE_KEY=${VAPID_PRIVATE_KEY}
+      - ADMIN_EMAIL=${ADMIN_EMAIL}
+    depends_on:
+      - mysql
+
+  mysql:
+    image: mysql:8.0
+    command: >
+      --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_DATABASE: "operational"
+      MYSQL_ROOT_PASSWORD: "12345678"
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./data/conf.d:/etc/mysql/conf.d
+      - ./data/logs:/logs
+      - /usr/local/var/mysql:/var/lib/mysql

--- a/packages/content/selfhosted/docker.mdx
+++ b/packages/content/selfhosted/docker.mdx
@@ -12,6 +12,16 @@ import Code from "@operational.co/components/code/index.vue";
 
 Operational can be installed via docker-compose.
 
+## Install via Coolify
+
+Coolify is a Docker manager. It can control your VPS and install applications for you.
+
+Here's a video on setting up Operational via Coolify:
+
+<iframe width="100%" height="315" src="https://www.youtube.com/embed/4dFS6h4GFJA?si=PrS6yUdSgtceMj5P" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+## Install via Docker manually
+
 ### Step 1. Install Docker
 
 For local installations, you can install [Docker desktop from here](https://docs.docker.com/desktop/setup/install/windows-install/).

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "baseBranches": ["master"]
+}


### PR DESCRIPTION
Hey so i want to create a Helm Chart for this but since this repo has no docker image in a registry atm, i quickly decided to create this PR. If you have any wishes/change requests, shoot your shot, i didn't know what you need exactly, so i just created what i think would be nice :)

The releaserc is probably a bit excessive, just let me know what you need

Issue: https://github.com/operational-co/operational.co/issues/3

This PR:
- Adds renovate config to keep everything up to date (i recommend https://developer.mend.io/ for ease of use)
- Adds a workflow with three jobs: version, build and release - version and build run on PR to main for testing if a change in a PR will result in a broken docker image. only on push to master the images will be pushed and semantic-release creates a release after the images were built and pushed successfully

Recommendations and stuff to think about before merging this:
-  since the workflow will try to build the images on PRs to main for testing:
https://github.blog/open-source/maintainers/github-actions-update-helping-maintainers-combat-bad-actors/
[GitHub docs, How to approve workflow run from public forks](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks)
- what should actually be shown in the Release notes / which types of commits?
- preleases (via separate branch)?